### PR TITLE
Fixed typographical error, changed authorites to authorities in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Download all resources provided below: [Download ZIP File] (http://tiny.cc/OAC-B
 
 2011 OAC Buildings: [Download ZIP File] (http://tiny.cc/OAC-Shp-Buildings)
 
-2011 OAC Local Authorites (Shapefile per Local Authority): [Download ZIP File] (http://tiny.cc/OAC-Shp-LA)
+2011 OAC Local Authorities (Shapefile per Local Authority): [Download ZIP File] (http://tiny.cc/OAC-Shp-LA)
 
 2011 OAC Regions/Countries (Shapefile per Region or Country): [Download ZIP File] (http://tiny.cc/OAC-Shp-Regions)
 


### PR DESCRIPTION
@geogale, I've corrected a typographical error in the documentation of the [2011OAC](https://github.com/geogale/2011OAC) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
